### PR TITLE
chore: add release-please workflow for automated versioning and releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,22 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          # Use default GITHUB_TOKEN
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Python release type for proper version management
+          release-type: python


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate release management for the repository. The workflow uses the Release Please action to handle versioning and changelog generation for Python projects.

Automation and release management:

* Added a `.github/workflows/release-please.yml` workflow that triggers on pushes to the `main` branch, sets necessary permissions, and runs the `googleapis/release-please-action@v4` to automate Python release processes.